### PR TITLE
Fix passing extra parameters

### DIFF
--- a/PySense/PySense.py
+++ b/PySense/PySense.py
@@ -107,7 +107,7 @@ class PySense(BrandingMixIn.BrandingMixIn, ConnectionMixIn.ConnectionMixIn, Dash
         if param_dict is None:
             self.param_dict = {}
         else:
-            self.param_dict = {}
+            self.param_dict = param_dict
 
         default_dict = {
             'CUBE_CACHE_TIMEOUT_SECONDS': 60


### PR DESCRIPTION
Setting to an empty dict was not allowing me to use extra params later in my code. 