### PR TITLE
Remove requirement of full model for import target

### DIFF
--- a/Documentation/PySense.html
+++ b/Documentation/PySense.html
@@ -135,7 +135,7 @@ class PySense(BrandingMixIn.BrandingMixIn, ConnectionMixIn.ConnectionMixIn, Dash
         if param_dict is None:
             self.param_dict = {}
         else:
-            self.param_dict = {}
+            self.param_dict = param_dict
 
         default_dict = {
             &#39;CUBE_CACHE_TIMEOUT_SECONDS&#39;: 60
@@ -431,7 +431,7 @@ class PySense(BrandingMixIn.BrandingMixIn, ConnectionMixIn.ConnectionMixIn, Dash
         if param_dict is None:
             self.param_dict = {}
         else:
-            self.param_dict = {}
+            self.param_dict = param_dict
 
         default_dict = {
             &#39;CUBE_CACHE_TIMEOUT_SECONDS&#39;: 60

--- a/Documentation/PySenseMixIns/DataModelMixIn.html
+++ b/Documentation/PySenseMixIns/DataModelMixIn.html
@@ -31,7 +31,7 @@
 
 class DataModelMixIn:
 
-    def add_data_model(self, data_model, *, title=None, target_data_model=None):
+    def add_data_model(self, data_model, *, title=None, target_data_model_id=None):
         &#34;&#34;&#34;Adds a new data model to the instance.
 
         Sisense does not support this in Windows
@@ -56,8 +56,6 @@ class DataModelMixIn:
         &#34;&#34;&#34;
 
         PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, &#39;add_data_model&#39;)
-
-        target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
 
         query_params = {&#39;title&#39;: title, &#39;datamodelId&#39;: target_data_model_id}
         data_model_json = self.connector.rest_call(&#39;post&#39;, &#39;api/v2/datamodel-imports/schema&#39;,
@@ -125,7 +123,7 @@ class DataModelMixIn:
         for data_model in PySenseUtils.make_iterable(data_models):
             self.connector.rest_call(&#39;delete&#39;, &#39;api/v2/datamodels/{}&#39;.format(data_model.get_oid()))
 
-    def import_schema(self, path, *, title=None, target_data_model=None):
+    def import_schema(self, path, *, title=None, target_data_model_id=None):
         &#34;&#34;&#34;Import schema file from path
 
         Sisense does not support this in Windows
@@ -147,15 +145,13 @@ class DataModelMixIn:
         &#34;&#34;&#34;
         PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, &#39;import_schema&#39;)
 
-        target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
-
         query_params = {&#39;title&#39;: title, &#39;datamodelId&#39;: target_data_model_id}
         data_model_json = self.connector.rest_call(&#39;post&#39;, &#39;api/v2/datamodel-imports/schema&#39;,
                                                    query_params=query_params, json_payload=PySenseUtils.read_json(path))
 
         return PySenseDataModel.DataModel(self, data_model_json)
 
-    def import_sdata(self, path, *, title=None, target_data_model=None):
+    def import_sdata(self, path, *, title=None, target_data_model_id=None):
         &#34;&#34;&#34;Import sdata file from path
 
         Linux only
@@ -179,8 +175,6 @@ class DataModelMixIn:
             target_data_model: (Optional) The data model to update.
         &#34;&#34;&#34;
         PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, &#39;import_schema&#39;)
-
-        target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
 
         query_params = {&#39;title&#39;: title, &#39;datamodelId&#39;: target_data_model_id}
         data_model_json = self.connector.rest_call(&#39;post&#39;, &#39;api/v2/datamodel-imports/stream/full&#39;,
@@ -209,7 +203,7 @@ class DataModelMixIn:
 </summary>
 <pre><code class="python">class DataModelMixIn:
 
-    def add_data_model(self, data_model, *, title=None, target_data_model=None):
+    def add_data_model(self, data_model, *, title=None, target_data_model_id=None):
         &#34;&#34;&#34;Adds a new data model to the instance.
 
         Sisense does not support this in Windows
@@ -234,8 +228,6 @@ class DataModelMixIn:
         &#34;&#34;&#34;
 
         PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, &#39;add_data_model&#39;)
-
-        target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
 
         query_params = {&#39;title&#39;: title, &#39;datamodelId&#39;: target_data_model_id}
         data_model_json = self.connector.rest_call(&#39;post&#39;, &#39;api/v2/datamodel-imports/schema&#39;,
@@ -303,7 +295,7 @@ class DataModelMixIn:
         for data_model in PySenseUtils.make_iterable(data_models):
             self.connector.rest_call(&#39;delete&#39;, &#39;api/v2/datamodels/{}&#39;.format(data_model.get_oid()))
 
-    def import_schema(self, path, *, title=None, target_data_model=None):
+    def import_schema(self, path, *, title=None, target_data_model_id=None):
         &#34;&#34;&#34;Import schema file from path
 
         Sisense does not support this in Windows
@@ -325,15 +317,13 @@ class DataModelMixIn:
         &#34;&#34;&#34;
         PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, &#39;import_schema&#39;)
 
-        target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
-
         query_params = {&#39;title&#39;: title, &#39;datamodelId&#39;: target_data_model_id}
         data_model_json = self.connector.rest_call(&#39;post&#39;, &#39;api/v2/datamodel-imports/schema&#39;,
                                                    query_params=query_params, json_payload=PySenseUtils.read_json(path))
 
         return PySenseDataModel.DataModel(self, data_model_json)
 
-    def import_sdata(self, path, *, title=None, target_data_model=None):
+    def import_sdata(self, path, *, title=None, target_data_model_id=None):
         &#34;&#34;&#34;Import sdata file from path
 
         Linux only
@@ -358,8 +348,6 @@ class DataModelMixIn:
         &#34;&#34;&#34;
         PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, &#39;import_schema&#39;)
 
-        target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
-
         query_params = {&#39;title&#39;: title, &#39;datamodelId&#39;: target_data_model_id}
         data_model_json = self.connector.rest_call(&#39;post&#39;, &#39;api/v2/datamodel-imports/stream/full&#39;,
                                                    query_params=query_params, file=path)
@@ -373,7 +361,7 @@ class DataModelMixIn:
 <h3>Methods</h3>
 <dl>
 <dt id="PySense.PySenseMixIns.DataModelMixIn.DataModelMixIn.add_data_model"><code class="name flex">
-<span>def <span class="ident">add_data_model</span></span>(<span>self, data_model, *, title=None, target_data_model=None)</span>
+<span>def <span class="ident">add_data_model</span></span>(<span>self, data_model, *, title=None, target_data_model_id=None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Adds a new data model to the instance.</p>
@@ -402,7 +390,7 @@ add_data_model(new_data_model, target_data_model=old_data_model)</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def add_data_model(self, data_model, *, title=None, target_data_model=None):
+<pre><code class="python">def add_data_model(self, data_model, *, title=None, target_data_model_id=None):
     &#34;&#34;&#34;Adds a new data model to the instance.
 
     Sisense does not support this in Windows
@@ -427,8 +415,6 @@ add_data_model(new_data_model, target_data_model=old_data_model)</p>
     &#34;&#34;&#34;
 
     PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, &#39;add_data_model&#39;)
-
-    target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
 
     query_params = {&#39;title&#39;: title, &#39;datamodelId&#39;: target_data_model_id}
     data_model_json = self.connector.rest_call(&#39;post&#39;, &#39;api/v2/datamodel-imports/schema&#39;,
@@ -550,7 +536,7 @@ This parameter must be used with the limit parameter, and is intended for paging
 </details>
 </dd>
 <dt id="PySense.PySenseMixIns.DataModelMixIn.DataModelMixIn.import_schema"><code class="name flex">
-<span>def <span class="ident">import_schema</span></span>(<span>self, path, *, title=None, target_data_model=None)</span>
+<span>def <span class="ident">import_schema</span></span>(<span>self, path, *, title=None, target_data_model_id=None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Import schema file from path</p>
@@ -574,7 +560,7 @@ import_schema(path, target_data_model=old_data_model)</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def import_schema(self, path, *, title=None, target_data_model=None):
+<pre><code class="python">def import_schema(self, path, *, title=None, target_data_model_id=None):
     &#34;&#34;&#34;Import schema file from path
 
     Sisense does not support this in Windows
@@ -596,8 +582,6 @@ import_schema(path, target_data_model=old_data_model)</p>
     &#34;&#34;&#34;
     PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, &#39;import_schema&#39;)
 
-    target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
-
     query_params = {&#39;title&#39;: title, &#39;datamodelId&#39;: target_data_model_id}
     data_model_json = self.connector.rest_call(&#39;post&#39;, &#39;api/v2/datamodel-imports/schema&#39;,
                                                query_params=query_params, json_payload=PySenseUtils.read_json(path))
@@ -606,7 +590,7 @@ import_schema(path, target_data_model=old_data_model)</p>
 </details>
 </dd>
 <dt id="PySense.PySenseMixIns.DataModelMixIn.DataModelMixIn.import_sdata"><code class="name flex">
-<span>def <span class="ident">import_sdata</span></span>(<span>self, path, *, title=None, target_data_model=None)</span>
+<span>def <span class="ident">import_sdata</span></span>(<span>self, path, *, title=None, target_data_model_id=None)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Import sdata file from path</p>
@@ -632,7 +616,7 @@ If it does, try the file from UI to verify it is a PySense issue or a Sisense is
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def import_sdata(self, path, *, title=None, target_data_model=None):
+<pre><code class="python">def import_sdata(self, path, *, title=None, target_data_model_id=None):
     &#34;&#34;&#34;Import sdata file from path
 
     Linux only
@@ -656,8 +640,6 @@ If it does, try the file from UI to verify it is a PySense issue or a Sisense is
         target_data_model: (Optional) The data model to update.
     &#34;&#34;&#34;
     PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, &#39;import_schema&#39;)
-
-    target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
 
     query_params = {&#39;title&#39;: title, &#39;datamodelId&#39;: target_data_model_id}
     data_model_json = self.connector.rest_call(&#39;post&#39;, &#39;api/v2/datamodel-imports/stream/full&#39;,

--- a/PySense/PySenseMixIns/DataModelMixIn.py
+++ b/PySense/PySenseMixIns/DataModelMixIn.py
@@ -3,7 +3,7 @@ from PySense import PySenseDataModel, PySenseUtils, SisenseVersion
 
 class DataModelMixIn:
 
-    def add_data_model(self, data_model, *, title=None, target_data_model=None):
+    def add_data_model(self, data_model, *, title=None, target_data_model_id=None):
         """Adds a new data model to the instance.
 
         Sisense does not support this in Windows
@@ -28,8 +28,6 @@ class DataModelMixIn:
         """
 
         PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, 'add_data_model')
-
-        target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
 
         query_params = {'title': title, 'datamodelId': target_data_model_id}
         data_model_json = self.connector.rest_call('post', 'api/v2/datamodel-imports/schema',
@@ -97,7 +95,7 @@ class DataModelMixIn:
         for data_model in PySenseUtils.make_iterable(data_models):
             self.connector.rest_call('delete', 'api/v2/datamodels/{}'.format(data_model.get_oid()))
 
-    def import_schema(self, path, *, title=None, target_data_model=None):
+    def import_schema(self, path, *, title=None, target_data_model_id=None):
         """Import schema file from path
 
         Sisense does not support this in Windows
@@ -119,15 +117,13 @@ class DataModelMixIn:
         """
         PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, 'import_schema')
 
-        target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
-
         query_params = {'title': title, 'datamodelId': target_data_model_id}
         data_model_json = self.connector.rest_call('post', 'api/v2/datamodel-imports/schema',
                                                    query_params=query_params, json_payload=PySenseUtils.read_json(path))
 
         return PySenseDataModel.DataModel(self, data_model_json)
 
-    def import_sdata(self, path, *, title=None, target_data_model=None):
+    def import_sdata(self, path, *, title=None, target_data_model_id=None):
         """Import sdata file from path
 
         Linux only
@@ -151,8 +147,6 @@ class DataModelMixIn:
             target_data_model: (Optional) The data model to update.
         """
         PySenseUtils.validate_version(self, SisenseVersion.Version.LINUX, 'import_schema')
-
-        target_data_model_id = target_data_model.get_oid() if target_data_model is not None else None
 
         query_params = {'title': title, 'datamodelId': target_data_model_id}
         data_model_json = self.connector.rest_call('post', 'api/v2/datamodel-imports/stream/full',

--- a/Scripts/Migrations/MigrateSchemas.py
+++ b/Scripts/Migrations/MigrateSchemas.py
@@ -56,7 +56,7 @@ dev_data_model = dev_client.get_data_models(title=data_model_to_migrate)
 
 if overwrite:
     prod_data_model = prod_client.get_data_models(title=data_model_to_overwrite)
-    prod_client.add_data_model(dev_data_model, target_data_model=prod_data_model)
+    prod_client.add_data_model(dev_data_model, target_data_model_id=prod_data_model.get_oid())
 else:
     title = new_title if new_title is not None else None
     prod_client.add_data_model(dev_data_model, title=title)

--- a/Test/PySenseDataModelTests.py
+++ b/Test/PySenseDataModelTests.py
@@ -23,12 +23,12 @@ class PySenseDataModelTests(unittest.TestCase):
         new_data_model = self.py_client.import_schema(self.resources + 'AnotherModel.smodel')
         assert new_data_model is not None
         new_data_model = self.py_client.import_schema(self.resources + 'AnotherModel.smodel',
-                                                  target_data_model=new_data_model)
+                                                  target_data_model_id=new_data_model.get_oid())
         path = new_data_model.export_to_smodel(self.tmp + 'Temp.smodel')
         os.remove(path)
         path = new_data_model.export_to_sdata(self.tmp + 'Temp.sdata')
         # This method often fails due to API limitations
-        # new_data_model = self.py_client.import_sdata(self.tmp + 'Temp.sdata', target_data_model=self.data_model)
+        # new_data_model = self.py_client.import_sdata(self.tmp + 'Temp.sdata', target_data_model_id=self.data_model.get_oid())
         os.remove(path)
 
         self.py_client.delete_data_models(new_data_model)


### PR DESCRIPTION
I'm having trouble exporting a datamodel and importing that same datamodel at a later time. The export works fine, but the document returned by the API and stored is missing an `oid` field

```bash
curl -skL -X GET -H "authorization: Bearer ${TOKEN}" \
   -H "accept: application/json" \
   -H "content-type: application/json" \
   'https://${URL}/api/v2/datamodel-exports/schema?datamodelId=${UUID}&type=schema-latest' | jq -r '.oid'
null
```

It appears the import process wants to validate that the stored smodel has an `oid` field.

https://github.com/nathangiusti/PySense/blob/f011e44cf37aa4119b7e801a664c7f91e88e3677/PySense/PySenseMixIns/DataModelMixIn.py#L122

I tried correcting this locally by injecting the `oid` into the stored document but then the API complains that an `oid` field exists when it shouldn't:
```python
PySense.PySenseException.PySenseException: ERROR: 400: b'{"type":"https://errors.sisense.dev/http/general-error","title":"EcmApiError","status":400,"sub":1012,"detail":"Variable \\"$cubeData\\" got invalid value { title: \\"<TITLE>\\", type: \\"extract\\", relations: [[Object], [Object], [Object], [Object], [Object], [Object]], datasets: [[Object], [Object]], oid: \\"<UUID>\\" }; Field \\"oid\\" is not defined by type \\"ElasticubeImportInput\\"."}'
URL: <URL>
```

It looks safe to remove the full object requirement since the only usage is to get the `oid`. Is this an acceptable solution, or perhaps I'm just doing it wrong?