### PR TITLE
fixed auth bug. host formatted as https

### DIFF
--- a/PySense/PySenseUtils.py
+++ b/PySense/PySenseUtils.py
@@ -2,14 +2,22 @@ import json
 
 from collections.abc import Iterable
 from datetime import datetime
+from urllib.parse import urlparse, urlunparse
 
 from PySense import PySenseException
 
 
 def format_host(host):
     """Formats host for PySense"""
-    if not host.startswith('http'):
-        host = 'http://' + host
+    parsed_host = urlparse(host)
+
+    # Add https string if no scheme provided. 
+    # Otherwise, host parsed as path not netloc.
+    if parsed_host.scheme == '':
+        parsed_host = urlparse('https://' + host)
+        host = urlunparse(parsed_host)
+    if parsed_host.scheme != 'https':
+        host = host.replace(parsed_host.scheme, 'https')
     if host.endswith('/'):
         host = host[:-1]
     return host

--- a/ReleaseNotesFull.md
+++ b/ReleaseNotesFull.md
@@ -1,3 +1,19 @@
+**V 1.0.7 Release Notes**
+
+- Breaking changes
+    - None
+
+- Additions
+    - None
+  
+- Fixes
+    - Updated format_host to return https scheme. Before http would be redirected to https causing API request method to change to GET. This caused errors for POST, PUT, etc.
+    
+- Known Issues
+    - REST API sometimes becomes unresponsive on Linux builds
+    - REST API sometimes fails uploading sdata files
+    
+
 **V 1.0.6 Release Notes**
 
 - Breaking changes


### PR DESCRIPTION
Changed format_host to return host with https scheme. Before http was redirected to https, causing auth API request method to update from POST to GET, which caused sisense to return 405 error. Please reach out if you have any questions.